### PR TITLE
feature/#14-coupon-seoul-2021-1

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,12 +1,13 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - seoul-2021-1 쿠폰 지원 (#4)
 
 0.007     2020-01-18 00:38:29+09:00 Asia/Seoul
-    - 잘못 전달되는 연도 데이터를 올해 연도 데이터로 가정해서 처리 (https://github.com/opencloset/opencloset/issues/1646)
+    - 잘못 전달되는 연도 데이터를 올해 연도 데이터로 가정해서 처리 (opencloset/opencloset#1646)
 
 0.006     2020-01-17 23:54:21+09:00 Asia/Seoul
-    - seoul-2020-1 쿠폰 지원 (https://github.com/opencloset/opencloset/issues/1646)
+    - seoul-2020-1 쿠폰 지원 (opencloset/opencloset#1646)
 
 0.005     2019-01-15 12:54:32+09:00 Asia/Seoul
     - seoul-2019-1 쿠폰 지원 (#10)

--- a/lib/OpenCloset/Coupon/Web.pm
+++ b/lib/OpenCloset/Coupon/Web.pm
@@ -104,7 +104,7 @@ sub default_config {
         },
         site      => { name => "OpenCloset::Coupon::Web", },
         time_zone => "Asia/Seoul",
-        copyright => "2015-2017 THE OPEN CLOSET",
+        copyright => "2015-2021 THE OPEN CLOSET",
         secrets   => [],
         extra_static_paths   => [ "assets", "static" ],
         extra_renderer_paths => ["templates"],

--- a/lib/OpenCloset/Coupon/Web.pm
+++ b/lib/OpenCloset/Coupon/Web.pm
@@ -496,14 +496,24 @@ sub _public_routes {
     #$r->get("/login/forgot")->to("login#forgot_get");
     #$r->post("/login/forgot")->to("login#forgot_post");
 
-    ### FIXME
-    ### https://github.com/opencloset/opencloset/issues/1646
-    ### https://lh3.googleusercontent.com/-cWSkd3LpTrM/XiHQY1CM4OI/AAAAAAAAJuk/8Xo5ilaSu0AXPU28uAdNAIfvhNQcl-dGACK8BGAsYHg/s0/2020-01-17.jpg
-    ### 아이넷피아에서 넘어오는 URL 이 2020 년도임에도 2019 로 넘어옴
-    ### 이를 2019 쿠폰 요청이 넘어올 일은 없다고 가정하고, 임시로 2019 로 와도 2020 으로 처리
-    ### 2020 으로 바꿔달라고 요청할 것이고 변경된 이후에는 2019 로 들어오는 요청은 유효하지 않도록 처리할 예정
-    $r->get("/seoul/2019/1")->to("seoul#seoul_2020_1_get");
-    $r->get("/seoul/2020/1")->to("seoul#seoul_2020_1_get");
+    #
+    # NOW
+    #
+    # - 이제 해당 년도에는 정확한 해당 연도 쿠폰 URL으로 요청하도록 전달함
+    # - 구 주소는 모두 제거하고 지원하지 않음
+    #
+    # PREVIOUS
+    #
+    # - 아이넷피아에서 넘어오는 URL 이 2020 년도임에도 2019 로 넘어옴
+    # - 이를 2019 쿠폰 요청이 넘어올 일은 없다고 가정하고, 임시로 2019 로 와도 2020 으로 처리
+    # - 2020 으로 바꿔달라고 요청할 것이고 변경된 이후에는 2019 로 들어오는 요청은 유효하지 않도록 처리할 예정
+    #
+    # SEE ALSO
+    #
+    # - https://github.com/opencloset/opencloset/issues/1646
+    # - https://lh3.googleusercontent.com/-cWSkd3LpTrM/XiHQY1CM4OI/AAAAAAAAJuk/8Xo5ilaSu0AXPU28uAdNAIfvhNQcl-dGACK8BGAsYHg/s0/2020-01-17.jpg
+    #
+    $r->get("/seoul/2021/1")->to("seoul#seoul_2021_1_get");
 }
 
 sub _private_routes {

--- a/lib/OpenCloset/Coupon/Web/Controller/Seoul.pm
+++ b/lib/OpenCloset/Coupon/Web/Controller/Seoul.pm
@@ -519,7 +519,7 @@ sub _seoul_coupon_get {
     }
 }
 
-sub seoul_2020_1_get { $_[0]->_seoul_coupon_get("seoul-2020-1"); }
+sub seoul_2021_1_get { $_[0]->_seoul_coupon_get("seoul-2021-1"); }
 
 1;
 
@@ -535,4 +535,4 @@ __END__
 
 ...
 
-=method seoul_2020_1_get
+=method seoul_2021_1_get


### PR DESCRIPTION
#14

작업한 내역은 다음과 같습니다.

- 2021년 서울 쿠폰 지원
- 구 쿠폰 주소 컨트롤러 제거
- 카피라이트 문구 수정